### PR TITLE
fix: handle ModuleNotFoundError on macos

### DIFF
--- a/xontrib/xlsd.xsh
+++ b/xontrib/xlsd.xsh
@@ -132,7 +132,7 @@ try:
             if fnmatch(mimetype, pattern):
                 return icon_name
         return None
-finally:
+except ModuleNotFoundError:
     pass
 
 


### PR DESCRIPTION
Hey,

Cool xontrib! Thank you.

I'm on macos and run into the following error when loading

```  
  File "/Users/deeuu/.local/share/virtualenvs/xonsh/lib/python3.8/site-packages/xontrib/xlsd.xsh", line 116, in <module>
    import magic
ModuleNotFoundError: No module named 'magic'
Failed to load xontrib xlsd.
```

which is now handled by this patch.

Cheers