### PR TITLE
feat(ui): Add single whitespace between icon & name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
       - [Changing the columns/the order](#changing-the-columnsthe-order)
       - [Writing your own column](#writing-your-own-column)
    - [Colors](#colors)
+   - [Item name](#item-name)
 
 # How to install xontrib-xlsd
 
@@ -187,3 +188,7 @@ xlsd.COLORS['size_unit'] = '{INTENSE_RED}'
 You can use any valid xonsh color.
 
 For a quick list of colors/text effects, check out the [xonsh tutorial on colors](https://xon.sh/tutorial.html#customizing-the-prompt).
+
+## Item Name
+
+By default, xlsd prints the item name with `{icon} {name}` format. You can update the `$XLSD_NAME_FORMAT` environment variable to change the format of the item. For example `$XLSD_NAME_FORMAT={icon}{name}` will remove the single space between icon & name.

--- a/xontrib/xlsd.xsh
+++ b/xontrib/xlsd.xsh
@@ -321,7 +321,7 @@ def _format_direntry_name(entry: os.DirEntry, show_target: bool = True) -> str:
     # Show the icon
     icon = _icon_for_direntry(entry)
     colors = []
-    name = $XLSD_NAME_FORMAT.format(icon=icon, name=name) + "{{RESET}}"
+    name = $XLSD_NAME_FORMAT.format(icon=icon, name=name) + "{RESET}"
 
     # if entry is a directory, add a trailing '/'
     try:

--- a/xontrib/xlsd.xsh
+++ b/xontrib/xlsd.xsh
@@ -122,6 +122,7 @@ def list_to_csv(x):
     return ",".join(x)
 
 
+${...}.register('XLSD_NAME_FORMAT', type="str", default='{icon} {name}')
 ${...}.register('XLSD_SORT_METHOD', type="str", default='directories_first')
 ${...}.register('XLSD_LIST_COLUMNS', validate=is_string_seq, convert=csv_to_list,
     detype=list_to_csv, default=['mode', 'hardlinks', 'uid', 'gid', 'size', 'mtime', 'name'])
@@ -320,7 +321,7 @@ def _format_direntry_name(entry: os.DirEntry, show_target: bool = True) -> str:
     # Show the icon
     icon = _icon_for_direntry(entry)
     colors = []
-    name = "{} {}{{RESET}}".format(icon, name)
+    name = $XLSD_NAME_FORMAT.format(icon=icon, name=name) + "{{RESET}}"
 
     # if entry is a directory, add a trailing '/'
     try:

--- a/xontrib/xlsd.xsh
+++ b/xontrib/xlsd.xsh
@@ -320,7 +320,7 @@ def _format_direntry_name(entry: os.DirEntry, show_target: bool = True) -> str:
     # Show the icon
     icon = _icon_for_direntry(entry)
     colors = []
-    name = "{}{}{{RESET}}".format(icon, name)
+    name = "{} {}{{RESET}}".format(icon, name)
 
     # if entry is a directory, add a trailing '/'
     try:


### PR DESCRIPTION
As a UI developer, I think there should a space between rendered icon and text so icon doesn't get stick to file/dir name.

NOTE: I just saw the code and made PR, if there's anything breaking please let me know.